### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/sql_server/pyodbc/base.py
+++ b/sql_server/pyodbc/base.py
@@ -8,16 +8,16 @@ import time
 from django.core.exceptions import ImproperlyConfigured
 from django import VERSION
 if VERSION[:3] < (1,10,4) or VERSION[:2] >= (1,11):
-    raise ImproperlyConfigured("Django %d.%d.%d is not supported." % VERSION[:3])
+    raise ImproperlyConfigured("Django {0:d}.{1:d}.{2:d} is not supported.".format(*VERSION[:3]))
 
 try:
     import pyodbc as Database
 except ImportError as e:
-    raise ImproperlyConfigured("Error loading pyodbc module: %s" % e)
+    raise ImproperlyConfigured("Error loading pyodbc module: {0!s}".format(e))
 
 pyodbc_ver = tuple(map(int, Database.version.split('.')[:2]))
 if pyodbc_ver < (3, 0):
-    raise ImproperlyConfigured("pyodbc 3.0 or newer is required; you have %s" % Database.version)
+    raise ImproperlyConfigured("pyodbc 3.0 or newer is required; you have {0!s}".format(Database.version))
 
 from django.conf import settings
 from django.db.backends.base.base import BaseDatabaseWrapper
@@ -50,7 +50,7 @@ def encode_connection_string(fields):
     # As the keys are all provided by us, don't need to encode them as we know
     # they are ok.
     return ';'.join(
-        '%s=%s' % (k, encode_value(v))
+        '{0!s}={1!s}'.format(k, encode_value(v))
         for k, v in fields.items()
     )
 
@@ -59,7 +59,7 @@ def encode_value(v):
     then enclose it in curly braces and escape all right curly braces.
     """
     if ';' in v or v.strip(' ').startswith('{'):
-        return '{%s}' % (v.replace('}', '}}'),)
+        return '{{{0!s}}}'.format(v.replace('}', '}}'))
     return v
 
 class DatabaseWrapper(BaseDatabaseWrapper):
@@ -199,7 +199,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             for op in self.operators:
                 sql = self.operators[op]
                 if sql.startswith('LIKE '):
-                    ops[op] = '%s COLLATE %s' % (sql, collation)
+                    ops[op] = '{0!s} COLLATE {1!s}'.format(sql, collation)
             self.operators.update(ops)
 
         self.features = DatabaseFeatures(self)
@@ -358,7 +358,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         # hasn't told us otherwise
         options = settings_dict.get('OPTIONS', {})
         datefirst = options.get('datefirst', 7)
-        cursor.execute('SET DATEFORMAT ymd; SET DATEFIRST %s' % datefirst)
+        cursor.execute('SET DATEFORMAT ymd; SET DATEFIRST {0!s}'.format(datefirst))
 
         # http://blogs.msdn.com/b/sqlnativeclient/archive/2008/02/27/microsoft-sql-server-native-client-and-microsoft-sql-server-2008-native-client.aspx
         try:
@@ -392,7 +392,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             ver = cursor.fetchone()[0]
             ver = int(ver.split('.')[0])
             if not ver in self._sql_server_versions:
-                raise NotImplementedError('SQL Server v%d is not supported.' % ver)
+                raise NotImplementedError('SQL Server v{0:d} is not supported.'.format(ver))
             return self._sql_server_versions[ver]
 
     @cached_property

--- a/sql_server/pyodbc/client.py
+++ b/sql_server/pyodbc/client.py
@@ -37,7 +37,7 @@ class DatabaseClient(BaseDatabaseClient):
                 args += ["-i", defaults_file]
         else:
             dsn = options.get('dsn', '')
-            args = ['%s -v %s %s %s' % (self.executable_name, dsn, user, password)]
+            args = ['{0!s} -v {1!s} {2!s} {3!s}'.format(self.executable_name, dsn, user, password)]
 
         import subprocess
         try:

--- a/sql_server/pyodbc/creation.py
+++ b/sql_server/pyodbc/creation.py
@@ -18,14 +18,12 @@ class DatabaseCreation(BaseDatabaseCreation):
             time.sleep(1)
             to_azure_sql_db = self.connection.to_azure_sql_db
             if not to_azure_sql_db:
-                cursor.execute("ALTER DATABASE %s SET SINGLE_USER WITH ROLLBACK IMMEDIATE"
-                                % self.connection.ops.quote_name(test_database_name))
-            cursor.execute("DROP DATABASE %s"
-                           % self.connection.ops.quote_name(test_database_name))
+                cursor.execute("ALTER DATABASE {0!s} SET SINGLE_USER WITH ROLLBACK IMMEDIATE".format(self.connection.ops.quote_name(test_database_name)))
+            cursor.execute("DROP DATABASE {0!s}".format(self.connection.ops.quote_name(test_database_name)))
 
     def sql_table_creation_suffix(self):
         suffix = []
         collation = self.connection.settings_dict['TEST'].get('COLLATION', None)
         if collation:
-            suffix.append('COLLATE %s' % collation)
+            suffix.append('COLLATE {0!s}'.format(collation))
         return ' '.join(suffix)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:nschonni:django-pyodbc-azure?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:nschonni:django-pyodbc-azure?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)